### PR TITLE
Dependabot Alert Remediation : Pillow ver upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ pandocfilters==1.4.3
 parso==0.8.2
 pexpect==4.8.0
 pickleshare==0.7.5
-Pillow==8.3.1
+Pillow==8.3.2
 prometheus-client==0.11.0
 prompt-toolkit==3.0.20
 protobuf==3.17.3


### PR DESCRIPTION
Upgrading Pillow to 8.3.2 to remediate Dependabot security alert